### PR TITLE
Removes threadqueue for C++ wqueue

### DIFF
--- a/build/ipop-tincan.gyp
+++ b/build/ipop-tincan.gyp
@@ -73,8 +73,6 @@
         'ipop-project/ipop-tap/src/win32_tap.h',
         'ipop-project/ipop-tap/src/translator.c',
         'ipop-project/ipop-tap/src/translator.h',
-        'ipop-project/ipop-tap/lib/threadqueue/threadqueue.c',
-        'ipop-project/ipop-tap/lib/threadqueue/threadqueue.h',
         'ipop-project/ipop-tap/lib/klib/khash.h',
       ],
     },  # target ipop-tap

--- a/src/controlleraccess.cc
+++ b/src/controlleraccess.cc
@@ -63,11 +63,9 @@ static void init_map() {
 
 ControllerAccess::ControllerAccess(
     TinCanConnectionManager& manager, XmppNetwork& network,
-    talk_base::BasicPacketSocketFactory* packet_factory,
-    struct threadqueue* controller_queue)
+    talk_base::BasicPacketSocketFactory* packet_factory)
     : manager_(manager),
-      network_(network),
-      controller_queue_(controller_queue) {
+      network_(network) {
   socket_.reset(packet_factory->CreateUdpSocket(
       talk_base::SocketAddress(kLocalHost, kUdpPort), 0, 0));
   socket_->SignalReadPacket.connect(this, &ControllerAccess::HandlePacket);
@@ -80,8 +78,7 @@ ControllerAccess::ControllerAccess(
 
 void ControllerAccess::ProcessIPPacket(talk_base::AsyncPacketSocket* socket,
     const char* data, size_t len, const talk_base::SocketAddress& addr) {
-  int count = thread_queue_bput(controller_queue_, data, len);
-  TinCanConnectionManager::HandleQueueSignal(0);
+  manager_.SendToTap(data, len);
 }
 
 void ControllerAccess::SendTo(const char* pv, size_t cb,

--- a/src/controlleraccess.h
+++ b/src/controlleraccess.h
@@ -43,8 +43,7 @@ class ControllerAccess : public PeerSignalSenderInterface,
                          public sigslot::has_slots<> {
  public:
   ControllerAccess(TinCanConnectionManager& manager, XmppNetwork& network,
-         talk_base::BasicPacketSocketFactory* packet_factory,
-         struct threadqueue* controller_queue_);
+         talk_base::BasicPacketSocketFactory* packet_factory);
 
   // Inherited from PeerSignalSenderInterface
   virtual void SendToPeer(int overlay_id, const std::string& uid,
@@ -68,7 +67,6 @@ class ControllerAccess : public PeerSignalSenderInterface,
   talk_base::SocketAddress remote_addr_;
   talk_base::scoped_ptr<talk_base::AsyncPacketSocket> socket_;
   talk_base::scoped_ptr<talk_base::AsyncPacketSocket> socket6_;
-  struct threadqueue* controller_queue_;
 };
 
 }  // namespace tincan

--- a/src/wqueue.h
+++ b/src/wqueue.h
@@ -1,0 +1,71 @@
+/*
+   wqueue.h
+
+   Worker thread queue based on the Standard C++ library list
+   template class.
+
+   ------------------------------------------
+
+   Copyright @ 2013 [Vic Hargrave - http://vichargrave.com]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef __wqueue_h__
+#define __wqueue_h__
+
+#include <pthread.h>
+#include <list>
+
+using namespace std;
+
+template <typename T> class wqueue
+{
+    list<T>          m_queue;
+    pthread_mutex_t  m_mutex;
+    pthread_cond_t   m_condv; 
+
+  public:
+    wqueue() {
+        pthread_mutex_init(&m_mutex, NULL);
+        pthread_cond_init(&m_condv, NULL);
+    }
+    ~wqueue() {
+        pthread_mutex_destroy(&m_mutex);
+        pthread_cond_destroy(&m_condv);
+    }
+    void add(T item) {
+        pthread_mutex_lock(&m_mutex);
+        m_queue.push_back(item);
+        pthread_cond_signal(&m_condv);
+        pthread_mutex_unlock(&m_mutex);
+    }
+    T remove() {
+        pthread_mutex_lock(&m_mutex);
+        while (m_queue.size() == 0) {
+            pthread_cond_wait(&m_condv, &m_mutex);
+        }
+        T item = m_queue.front();
+        m_queue.pop_front();
+        pthread_mutex_unlock(&m_mutex);
+        return item;
+    }
+    int size() {
+        pthread_mutex_lock(&m_mutex);
+        int size = m_queue.size();
+        pthread_mutex_unlock(&m_mutex);
+        return size;
+    }
+};
+
+#endif


### PR DESCRIPTION
This commit uses an Apache licensed wqueue implementation (https://github.com/vichargrave/wqueue), queues have to be global primarily because static functions (necessary to link with C code ... ipop-tap) will be accessing them.
