### PR TITLE
[DEBUG] Packet is not forwarded to controller

### DIFF
--- a/src/tincanconnectionmanager.cc
+++ b/src/tincanconnectionmanager.cc
@@ -202,8 +202,11 @@ void TinCanConnectionManager::HandlePacket(talk_base::AsyncPacketSocket* socket,
   if (dest.compare(0, 3, "000") == 0) {
     forward_socket_->SendTo(data, len, forward_addr_,talk_base::DSCP_DEFAULT);
   } 
-  else if (short_uid_map_.find(dest) != short_uid_map_.end() &&
-           short_uid_map_[dest]->writable()) {
+  else if (short_uid_map_.find(dest) == short_uid_map_.end()) { 
+    forward_socket_->SendTo(data, len, forward_addr_,talk_base::DSCP_DEFAULT); 
+  } 
+  else if (short_uid_map_[dest]->writable()) {
+    LOG_F(INFO) << "found in uid map and send packet to channel\n"; 
     int component = cricket::ICE_CANDIDATE_COMPONENT_DEFAULT;
     cricket::TransportChannelImpl* channel = 
         short_uid_map_[dest]->GetChannel(component);


### PR DESCRIPTION
Even if the transport is destroyed and the connection does not
exist in uid_map_, the packet is not forwarded to controller.
This error occurs when destination address exists in peerlist in tap
module and forwarded to tincan manager with non-zero destination uid.
In detail, after connection is destroyed, we still keep the ipv4-uid
mapping in tap peerlist and forward to tincan manager with its
previous uid. So I add logic in tincan manager to forward packet with
non-zero uid that does not exist in uid_map_.
