### PR TITLE
Fix memory leak in DestroyTransport.

### DIFF
--- a/src/tincanconnectionmanager.cc
+++ b/src/tincanconnectionmanager.cc
@@ -459,10 +459,6 @@ bool TinCanConnectionManager::CreateConnections(
 
 bool TinCanConnectionManager::DestroyTransport(const std::string& uid) {
   if (uid_map_.find(uid) == uid_map_.end()) return false;
-  // TODO - This is a memory leak, we don't always have to release
-  // For some reason, this causes a segfault when destroying the
-  // port allocator object, maybe it gets cleaned up by P2P transport
-  uid_map_[uid]->port_allocator.release();
 
   // This call destroys the P2P connection and deletes connection
   // because this calls destructor of PeerState which in turn calls the

--- a/src/tincanconnectionmanager.h
+++ b/src/tincanconnectionmanager.h
@@ -176,6 +176,10 @@ class TinCanConnectionManager : public talk_base::MessageHandler,
     talk_base::scoped_ptr<cricket::TransportDescription> remote_description;
     cricket::Candidates candidates;
     std::set<std::string> candidate_list;
+    ~PeerState() {
+      transport.reset();
+      port_allocator.reset();
+    }
   };
 
   struct PeerIPs {


### PR DESCRIPTION
Transport (and channels) depends on port_allocator, so we need delete
transport before deleting port_allocator.
The order of members in PeerState make default destructor to delete
port_allocator first, that may crash program in some situation.
# 

I tried on my machine for several times.
But it is hard to trigger the crash even without this commit.

I push this request so we can have more people to test it.
