### PR TITLE
Updates macros to include static variables on Win32

### DIFF
--- a/src/tincan_utils.h
+++ b/src/tincan_utils.h
@@ -39,6 +39,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sys/time.h>
+#endif //if defined(LINUX)
 
 namespace tincan {
 
@@ -66,5 +67,4 @@ class CurrentTime {
 
 } //namespace tincan
 
-#endif //if defined(LINUX)
 #endif //ifndef TINCAN_UTILS_H_


### PR DESCRIPTION
Code was not working on Windows because Linux #ifdef was comment code out. This fixes that.
