### PR TITLE
TAP interface is ignored by libjingle

### DIFF
--- a/src/tincanconnectionmanager.cc
+++ b/src/tincanconnectionmanager.cc
@@ -167,10 +167,12 @@ void TinCanConnectionManager::OnNetworksChanged() {
   // interface because we don't want libjingle to try to connect
   // over ipop network that can create weird conditions and break things
   for (size_t i = 0; i < networks.size(); ++i) {
-    if (networks[i]->name().compare(kTapName) == 0) {
-      networks[i]->ClearIPs();
+	  if (networks[i]->name().compare(kTapName) == 0 ||
+		  networks[i]->description().compare(0, 3, kTapDesc) == 0) {
+		  networks[i]->ClearIPs();
       // Set to a random ipv6 address in order to disable
       networks[i]->AddIP(ip6_addr.ipaddr());
+	  LOG_TS(INFO) << "IPOP TAP Device to be ignored " << networks[i]->name() << ":" << networks[i]->description();
     }
   }
 }

--- a/src/tincanconnectionmanager.h
+++ b/src/tincanconnectionmanager.h
@@ -60,6 +60,7 @@
 namespace tincan {
 
 static const char kTapName[] = "ipop";
+static const char kTapDesc[] = "TAP";
 
 class PeerSignalSender : public PeerSignalSenderInterface {
  public:


### PR DESCRIPTION
The existing code fails on Windows as the current version of libjingle names the interface with an enumerated numeral rather than the interface name "ipop". The fix is to examine the interface description in addition to the name. If the interface description starts with "TAP" it is configured to be ignored.
