### PR TITLE
Switchmode handling is moved from controller to TinCan

### DIFF
--- a/src/controlleraccess.cc
+++ b/src/controlleraccess.cc
@@ -222,7 +222,9 @@ void ControllerAccess::HandlePacket(talk_base::AsyncPacketSocket* socket,
         int ip4_mask = root["ip4_mask"].asInt();
         int ip6_mask = root["ip6_mask"].asInt();
         int subnet_mask = root["subnet_mask"].asInt();
-        manager_.Setup(uid, ip4, ip4_mask, ip6, ip6_mask, subnet_mask);
+        int switchmode = root["switchmode"].asInt();
+        manager_.Setup(uid, ip4, ip4_mask, ip6, ip6_mask, subnet_mask,
+                       switchmode);
       }
       break;
     case SET_REMOTE_IP: {

--- a/src/tincanconnectionmanager.cc
+++ b/src/tincanconnectionmanager.cc
@@ -120,7 +120,7 @@ TinCanConnectionManager::TinCanConnectionManager(
 
 void TinCanConnectionManager::Setup(
     const std::string& uid, const std::string& ip4, int ip4_mask,
-    const std::string& ip6, int ip6_mask, int subnet_mask) {
+    const std::string& ip6, int ip6_mask, int subnet_mask, int switchmode) {
 
   // input verification before proceeding
   if (!tincan_id_.empty() || uid.size() != kIdSize) return;
@@ -148,6 +148,7 @@ void TinCanConnectionManager::Setup(
   error |= tap_set_ipv4_addr(ip4.c_str(), ip4_mask);
   error |= tap_set_ipv6_addr(ip6.c_str(), ip6_mask);
   error |= tap_set_mtu(MTU) | tap_set_base_flags() | tap_set_up();
+  if (switchmode) { error |= tap_unset_noarp_flags(); }
 #endif
   // set up ipop-tap parameters
   error |= peerlist_set_local_p(uid_str, ip4.c_str(), ip6.c_str());
@@ -478,7 +479,11 @@ bool TinCanConnectionManager::AddIPMapping(
   override_base_ipv4_addr_p(ip4.c_str());
 
   // this create a UID to IP mapping in the ipop-tap peerlist
-  peerlist_add_p(uid_str, ip4.c_str(), ip6.c_str(), 0);
+  if (ip4 == "127.0.0.1" ) { //TODO should be changed with switchmode flag
+    peerlist_add_by_uid(uid_str);
+  } else {
+    peerlist_add_p(uid_str, ip4.c_str(), ip6.c_str(), 0);
+  }
   PeerIPs ips;
   ips.ip4 = ip4;
   ips.ip6 = ip6;

--- a/src/tincanconnectionmanager.h
+++ b/src/tincanconnectionmanager.h
@@ -147,7 +147,7 @@ class TinCanConnectionManager : public talk_base::MessageHandler,
   // Other public functions
   virtual void Setup(
       const std::string& uid, const std::string& ip4, int ip4_mask,
-      const std::string& ip6, int ip6_mask, int subnet_mask);
+      const std::string& ip6, int ip6_mask, int subnet_mask, int switchmode);
 
   virtual bool CreateTransport(
       const std::string& uid, const std::string& fingerprint, int overlay_id,


### PR DESCRIPTION
For performance reason, we moved switchmode hanlding from overlay
controllers to TinCan.
 - To disable NOARP in tap device in switchmode, we added one more argument in
   controller API call SET_LOCAL_IP
 - On switchmode, when remote peer connected, we only add UID of remote peer to
   peerlist.