### PR TITLE
ARP reply feature for ARPing tap

### DIFF
--- a/src/tincan.cc
+++ b/src/tincan.cc
@@ -121,7 +121,7 @@ int main(int argc, char **argv) {
 
   tincan::PeerSignalSender signal_sender;
   tincan::TinCanConnectionManager manager(&signal_sender, &link_setup_thread,
-                                         &packet_handling_thread);
+                                         &packet_handling_thread, &opts);
   tincan::XmppNetwork xmpp(&link_setup_thread);
   xmpp.HandlePeer.connect(&manager,
       &tincan::TinCanConnectionManager::HandlePeer);

--- a/src/tincanconnectionmanager.cc
+++ b/src/tincanconnectionmanager.cc
@@ -89,7 +89,8 @@ enum {
 TinCanConnectionManager::TinCanConnectionManager(
     PeerSignalSenderInterface* signal_sender,
     talk_base::Thread* link_setup_thread,
-    talk_base::Thread* packet_handling_thread)
+    talk_base::Thread* packet_handling_thread,
+    thread_opts_t* opts)
     : content_name_(kContentName),
       signal_sender_(signal_sender),
       packet_factory_(packet_handling_thread),
@@ -108,7 +109,8 @@ TinCanConnectionManager::TinCanConnectionManager(
       tincan_ip6_(kIpv6),
       tap_name_(kTapName),
       packet_options_(talk_base::DSCP_DEFAULT),
-      trim_enabled_(false) {
+      trim_enabled_(false),
+      opts_(opts) {
   // we have to set the global point for ipop-tap communication
   g_manager = this;
 
@@ -145,7 +147,7 @@ void TinCanConnectionManager::Setup(
   int error = 0;
 #if defined(LINUX) || defined(ANDROID)
   // Configure ipop tap VNIC through Linux sys calls
-  error |= tap_set_ipv4_addr(ip4.c_str(), ip4_mask);
+  error |= tap_set_ipv4_addr(ip4.c_str(), ip4_mask, opts_->my_ip4);
   error |= tap_set_ipv6_addr(ip6.c_str(), ip6_mask);
   error |= tap_set_mtu(MTU) | tap_set_base_flags() | tap_set_up();
   if (switchmode) { error |= tap_unset_noarp_flags(); }

--- a/src/tincanconnectionmanager.h
+++ b/src/tincanconnectionmanager.h
@@ -86,7 +86,8 @@ class TinCanConnectionManager : public talk_base::MessageHandler,
  public:
   TinCanConnectionManager(PeerSignalSenderInterface* signal_sender,
                           talk_base::Thread* link_setup_thread,
-                          talk_base::Thread* packet_handling_thread);
+                          talk_base::Thread* packet_handling_thread,
+                          thread_opts_t* opts);
 
   // Accessors
   const std::string fingerprint() const { return fingerprint_; }
@@ -241,6 +242,7 @@ class TinCanConnectionManager : public talk_base::MessageHandler,
   talk_base::SocketAddress forward_addr_;
   talk_base::PacketOptions packet_options_;
   bool trim_enabled_;
+  thread_opts_t* opts_;
 };
 
 }  // namespace tincan


### PR DESCRIPTION
In switchmode, when we PING to local/remote tap itself from its clients, it was intermittently not working. The reason was that our tap device does not have feature of making ARP reply message and sends back to the source. But, PINGing to tap usually works because bridge itself can make ARP reply message instead of tap device. 
It is default network interface behavior in Linux. When multiple interfaces attached to same host and they are in the same subnet, neighboring network interface can make ARP reply message instead of the destined network interface.

But, tap cannot reply to ARP if we are not using linux bridge nor the bridge does not knows the neighbor mac/ipv4.

This feature is necessary for inter-controller communication when tap is attached to openvswitch.

ARP reply message is created in tap. For local ARP message, the message is read from the tap and write back ARP reply message to tap.
For the remote ARP message, ARP request message comes from the TinCan link to tap device. Then create ARP reply message from given ARP request message and sends back to the source TinCan link.