### PR TITLE
ICC API is added

### DIFF
--- a/src/controlleraccess.cc
+++ b/src/controlleraccess.cc
@@ -173,6 +173,12 @@ void ControllerAccess::HandlePacket(talk_base::AsyncPacketSocket* socket,
                      << " controller:" << data[0];
   }
   if (data[1] == kTincanPacket) return ProcessIPPacket(socket, data, len, addr);
+  if (data[1] == kICCControl || data[1] == kICCPacket) {
+    /* ICC message is received from controller. Remove IPOP version and type
+       field and pass to TinCan Connection manager */
+    manager_.HandlePacket(0, data+2, len-2, addr);
+    return;
+  }
   if (data[1] != kTincanControl) {
     LOG_TS(LS_ERROR) << "Unknown message type"; 
   }

--- a/src/tincan_utils.h
+++ b/src/tincan_utils.h
@@ -55,11 +55,14 @@ Tincan Packet  : data packet forward from/to controllers
 */
 static const char kTincanControl = 0x01;
 static const char kTincanPacket = 0x02;
+static const char kICCControl = 0x03; //Intercontroller connection header
+static const char kICCPacket = 0x04; //Intercontroller connection header
 
 static const int kTincanVerOffset = 0;
 static const int kTincanMsgTypeOffset = 1;
 
 static const int kTincanHeaderSize = 2;
+static const int kICCMacOffset = 5;
 
 class CurrentTime {
   friend std::ostream & operator << (std::ostream &, const CurrentTime &);

--- a/src/tincanconnectionmanager.h
+++ b/src/tincanconnectionmanager.h
@@ -219,6 +219,7 @@ class TinCanConnectionManager : public talk_base::MessageHandler,
                 const std::string& username, const std::string& password);
   void GetChannelStats_w(const std::string &uid,
                          cricket::ConnectionInfos *infos);
+  bool is_icc(const unsigned char * buf);
 
   const std::string content_name_;
   PeerSignalSenderInterface* signal_sender_;


### PR DESCRIPTION
Previous ICC(inte-controller communication) has some problem working with switchmode. When IPOP is non-switchmode, it works as layer3 device and interact with O/S network stack as a layer3 device. So that we could open UDP or TCP socket on this ipop tap device. But after we attach tap device to layer 2 device(linux bridge or openvswitch), ipop renounce its layer 3 features and lost interaction with O/S network stack. For example, ARP reply message or ICMP Ping reply are not understood by O/S network stack. Those messages are just inside the bridge network itself. 

In this new ICC, we use TinCan link directly to send message between controllers. 

The message header from Controller to tincan is as below.
```
| 1 byte IPOP version field | 1 byte IPOP message type field | 20 byte source UID field | 20 byte destination uid field | 6 byte destination MAC address field |...
```

We use source uid and destination uid as an identifier for each controller node. 
We use destinatoin mac address as 00-69-70-6f-70-03 for ICC control message and  00-69-70-6f-70-04 for ICC packet message.  69-70-6f-70 is the ascii code for i-p-o-p and this address range is reserved field by mac protocol. 

The message header from source tincan to destination tincan is as below
```
| 20 byte source UID field | 20 byte destination uid field | 6 byte destination MAC address field |...
```

In the receiving end, receiving thread checks MAC field and if its ICC then nullities source and destination uid(for implementation convenience) then pass to controller. 





