### PR TITLE
added arguments to tincan

### DIFF
--- a/src/controlleraccess.cc
+++ b/src/controlleraccess.cc
@@ -26,10 +26,8 @@
 #include "tincan_utils.h"
 
 namespace tincan {
-
 static const char kLocalHost[] = "127.0.0.1";
 static const char kLocalHost6[] = "::1";
-static const int kUdpPort = 5800;
 static const int kBufferSize = 1024;
 static std::map<std::string, int> rpc_calls;
 
@@ -77,10 +75,10 @@ ControllerAccess::ControllerAccess(
       opts_(opts) {
   signal_thread_ = talk_base::Thread::Current();
   socket_.reset(packet_factory->CreateUdpSocket(
-      talk_base::SocketAddress(kLocalHost, kUdpPort), 0, 0));
+      talk_base::SocketAddress(kLocalHost, tincan::kUdpPort), 0, 0));
   socket_->SignalReadPacket.connect(this, &ControllerAccess::HandlePacket);
   socket6_.reset(packet_factory->CreateUdpSocket(
-      talk_base::SocketAddress(kLocalHost6, kUdpPort), 0, 0));
+      talk_base::SocketAddress(kLocalHost6, tincan::kUdpPort), 0, 0));
   socket6_->SignalReadPacket.connect(this, &ControllerAccess::HandlePacket);
   manager_.set_forward_socket(socket6_.get());
   init_map();

--- a/src/controlleraccess.h
+++ b/src/controlleraccess.h
@@ -34,6 +34,8 @@
 #include "tincanconnectionmanager.h"
 
 namespace tincan {
+//port is configurable via argument to tincan.
+extern int kUdpPort;
 
 class ControllerAccess : public PeerSignalSenderInterface,
                          public sigslot::has_slots<> {

--- a/src/tincan.cc
+++ b/src/tincan.cc
@@ -107,13 +107,19 @@ bool SSLVerificationCallback(void* cert) {
 void parse_args(int argc,char **args) {
   if (argc == 2 && strncmp(args[1], "-v", 2)==0)
     {
-      std::cout<<endl<<"Details and usage of tincan are as shown below"<<endl
-      << "To configure the name of tap device and listener port."<<endl
-      << "pass tap-name as first arg and port as second."<<endl<<endl
+      std::cout<<endl
       << "-----tincan version is-----"<< endl
       << tincan::kIpopVerMjr << "." << tincan::kIpopVerMnr << "." 
       << tincan::kIpopVerRev << endl;
       exit(0);
+    }
+  if (argc == 2 && strncmp(args[1], "-h", 2)==0)
+    {
+       std::cout<<endl<<"---OPTIONAL---"<<endl
+        << "To configure the name of tap device and listener port."<<endl
+        << "pass tap-name as first arg and port as second."<<endl
+        << "example--sudo sh -c './ipop-tincan looptap 5805 1> out.log 2> err.log &'"<< endl
+        exit(0);
     }
   if (argc == 3)
     {
@@ -133,7 +139,7 @@ int main(int argc, char **argv) {
   opts.tap = tap_open(tincan::kTapName.c_str(), opts.mac);
   if (opts.tap < 0) return -1;
 #elif defined(WIN32)
-  opts.win32_tap = open_tap(tincan::kTapName, opts.mac);
+  opts.win32_tap = open_tap(tincan::kTapName.c_str(), opts.mac);
   if (opts.win32_tap < 0) return -1;
 #endif
   opts.translate = 0;

--- a/src/tincanconnectionmanager.h
+++ b/src/tincanconnectionmanager.h
@@ -54,9 +54,9 @@
 #include "wqueue.h"
 
 namespace tincan {
-
-static const char kTapName[] = "ipop";
 static const char kTapDesc[] = "TAP";
+//name is configurable using argument passed to tincan.
+extern  string kTapName;
 
 class PeerSignalSender : public PeerSignalSenderInterface {
  public:


### PR DESCRIPTION
-- added argument handling to tincan to enable optional configuration for name of tap device and listener port.
-- argument "-v" prints on the console the version and usage for optional configuration.
-- kUdpPort moved from controlleraccess.cc to controlleraccess.h and changed from static to extern.
-- kTapName changed from char* to string.