### PR TITLE
Support configurable xmpp port

### DIFF
--- a/src/controlleraccess.cc
+++ b/src/controlleraccess.cc
@@ -28,6 +28,7 @@
 namespace tincan {
 static const char kLocalHost[] = "127.0.0.1";
 static const char kLocalHost6[] = "::1";
+static const int kDefaultXmppPort = 5222;
 static const int kBufferSize = 1024;
 static std::map<std::string, int> rpc_calls;
 
@@ -195,7 +196,10 @@ void ControllerAccess::HandlePacket(talk_base::AsyncPacketSocket* socket,
         std::string user = root["username"].asString();
         std::string pass = root["password"].asString();
         std::string host = root["host"].asString();
-		int port = root["port"].asInt();
+        int port = kDefaultXmppPort;
+        if (root.isMember("port")) {
+          port = root["port"].asInt();
+        }
         bool res = network_.Login(user, pass, manager_.uid(), host, port);
       }
       break;

--- a/src/controlleraccess.cc
+++ b/src/controlleraccess.cc
@@ -195,7 +195,8 @@ void ControllerAccess::HandlePacket(talk_base::AsyncPacketSocket* socket,
         std::string user = root["username"].asString();
         std::string pass = root["password"].asString();
         std::string host = root["host"].asString();
-        bool res = network_.Login(user, pass, manager_.uid(), host);
+		int port = root["port"].asInt();
+        bool res = network_.Login(user, pass, manager_.uid(), host, port);
       }
       break;
     case CREATE_LINK: {

--- a/src/tincan.cc
+++ b/src/tincan.cc
@@ -37,11 +37,9 @@
 #include "tincan_utils.h"
 #include "xmppnetwork.h"
 
-
 #define SEGMENT_SIZE 3
 #define SEGMENT_OFFSET 4
 #define CMP_SIZE 7
-
 
 namespace tincan {
 int kUdpPort = 5800;

--- a/src/tincan.cc
+++ b/src/tincan.cc
@@ -37,9 +37,11 @@
 #include "tincan_utils.h"
 #include "xmppnetwork.h"
 
+
 #define SEGMENT_SIZE 3
 #define SEGMENT_OFFSET 4
 #define CMP_SIZE 7
+
 
 namespace tincan {
 int kUdpPort = 5800;
@@ -132,7 +134,7 @@ void parse_args(int argc,char **args) {
 int main(int argc, char **argv) {
   // Parse arguments
   parse_args(argc,argv);
-  talk_base::InitializeSSL(SSLVerificationCallback);
+  talk_base::InitializeSSL();
   peerlist_init();
   thread_opts_t opts;
 #if defined(LINUX) || defined(ANDROID)

--- a/src/xmppnetwork.cc
+++ b/src/xmppnetwork.cc
@@ -45,8 +45,6 @@ static const int kInterval = 15000;
 // this constant sets how often presense message is sent (sec)
 static const int kPresenceInterval = 120;
 
-static const int kXmppPort = 5222;
-
 static const buzz::StaticQName QN_TINCAN = { "jabber:iq:tincan", "query" };
 static const buzz::StaticQName QN_TINCAN_DATA = { "jabber:iq:tincan", "data" };
 static const buzz::StaticQName QN_TINCAN_TYPE = { "jabber:iq:tincan", "type" };
@@ -156,7 +154,7 @@ bool XmppNetwork::Login(std::string username, std::string password,
   xcs_.set_use_tls(buzz::TLS_REQUIRED);
   //xcs_.set_allow_plain(true);
   xcs_.set_pass(talk_base::CryptString(pass));
-  xcs_.set_server(talk_base::SocketAddress(host, port ? port : kXmppPort));
+  xcs_.set_server(talk_base::SocketAddress(host, port));
   return Connect();
 }
 

--- a/src/xmppnetwork.cc
+++ b/src/xmppnetwork.cc
@@ -141,7 +141,7 @@ bool TinCanTask::HandleStanza(const buzz::XmlElement* stanza) {
 }
 
 bool XmppNetwork::Login(std::string username, std::string password,
-                        std::string pcid, std::string host) {
+                        std::string pcid, std::string host, int port) {
   if (pump_.get() || username.empty() || password.empty() || 
       pcid.empty() || host.empty()) return false;
 
@@ -156,7 +156,7 @@ bool XmppNetwork::Login(std::string username, std::string password,
   xcs_.set_use_tls(buzz::TLS_REQUIRED);
   //xcs_.set_allow_plain(true);
   xcs_.set_pass(talk_base::CryptString(pass));
-  xcs_.set_server(talk_base::SocketAddress(host, kXmppPort));
+  xcs_.set_server(talk_base::SocketAddress(host, port ? port : kXmppPort));
   return Connect();
 }
 

--- a/src/xmppnetwork.h
+++ b/src/xmppnetwork.h
@@ -114,7 +114,7 @@ class XmppNetwork
   virtual void OnMessage(talk_base::Message* msg);
 
   bool Login(std::string username, std::string password,
-             std::string pcid, std::string host);
+             std::string pcid, std::string host, int port);
 
  private:
   bool Connect();


### PR DESCRIPTION
Hello, 
I didn't find any rule about ternary operator `exp ? x : y` in style guide. I assumed I can use it.

This path add support for configurable xmpp port. It has to be sent by controller in the `do_register_service`packet, so update to controller is needed

Removed `SSLVerificationCallback` because it caused an assertion in `talk\base\nsstreamadapter.cc` in line 99:

```
bool NSSContext::InitializeSSL(VerificationCallback callback) {
  ASSERT(!callback);
```
